### PR TITLE
implement base nyc configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # nyc-config
 Base Containership nyc config
+
+## Extending Configuration
+To extend the nyc configuration, simply specify the following in your project's `.nycrc` file:
+```json
+{
+    "extends": "@containership/nyc-config"
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+    reporter: [
+        'text-summary'
+    ],
+    cache: true,
+    all: true
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@containership/nyc-config",
+  "version": "0.0.0",
+  "description": "Base Containership nyc config",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/containership/nyc-config.git"
+  },
+  "author": "Containership Developers <developers@containership.io>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/containership/nyc-config/issues"
+  },
+  "homepage": "https://github.com/containership/nyc-config#readme"
+}


### PR DESCRIPTION
This will serve as the base `.nycrc` configuration file that other projects will extend from.